### PR TITLE
[ch1629] add correlation_id logging to response

### DIFF
--- a/lib/adp/api_connection.rb
+++ b/lib/adp/api_connection.rb
@@ -164,11 +164,14 @@ module Adp
         # add credentials if available
         request["Authorization"] = authorization unless authorization.nil?
 
-        response = JSON.parse(http.request(request).body)
+        response = http.request(request)
+        correlation_id = response['adp-correlationid']
+        parsed_response = JSON.parse(response.body)
+        log.debug("ADP Correlation ID: #{correlation_id}")
         if return_headers
-          [response, http.request(request).each_header.to_h]
+          [parsed_response, http.request(request).each_header.to_h]
         else
-          response
+          parsed_response
         end
       end
     end

--- a/lib/adp/authorization_code_connection.rb
+++ b/lib/adp/authorization_code_connection.rb
@@ -69,7 +69,7 @@ module Adp
           end
         end
 
-        log("connection configutration: #{self.connection_configuration.inspect}")
+        log("connection configuration: #{self.connection_configuration.inspect}")
 
         data = {
             "client_id" => self.connection_configuration.clientID,


### PR DESCRIPTION
This adds a logger to the ADP web request response to include a logger for the ADP correlation ID.

The correlation ID is used on ADP's end to help debug issues.

When there are issues with requests that we have, ADP will want us to send them the correlation ID that is stored in the response header